### PR TITLE
Fix graphql queries limit.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,7 @@ services:
       - --name=app
       - --playground
       - --indexer=http://subquery-node:3000
+      - --unsafe
 
   grafana:
     image: grafana/grafana:latest


### PR DESCRIPTION
Fix https://oak-network.atlassian.net/browse/ENG-362

Refers to:
https://doc.subquery.network/run_publish/references.html#unsafe-2
The query service has a limit of 100 entities for unbounded graphql queries. The unsafe flag removes this limit which may cause performance issues on the query service. 

If we are concerned about performance, we can query the postgres database directly.
