### PR TITLE
Fix ipfs-unixfs incompatible

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,9 @@
     "typescript": "^4.5.4",
     "@subql/cli": "^0.16.2"
   },
+  "resolutions": {
+    "ipfs-unixfs": "6.0.6"
+  },
   "exports": {
     "chaintypes": "src/chaintypes.ts"
   }


### PR DESCRIPTION
Fix the issue
```
error ipfs-unixfs@6.0.7: The engine "node" is incompatible with this module. Expected version ">=16.0.0". Got "14.19.1"
error Found incompatible module.
```

Refers to:
https://github.com/subquery/subql/discussions/926

This is due to upgrade of the [ipfs-unixfs](https://github.com/ipfs/js-ipfs-unixfs/releases/tag/ipfs-unixfs-v6.0.7) package, and this is been use as a dependency for our @subql/cli to publish project to IPFS.

We don't need to deploy to ipfs, so we won't be using this library.
