### PR TITLE
update network endpoint and genesis block

### DIFF
--- a/project-staging.yaml
+++ b/project-staging.yaml
@@ -1,7 +1,7 @@
 specVersion: 0.2.0
-name: neumann-subql
+name: turing-staging-subql
 version: 0.0.4
-description: Any queries for subquery for OAK's neumann network
+description: Any queries for subquery for Turing Staging network
 repository: https://github.com/oak/oak-subql
 schema:
   file: ./schema.graphql

--- a/project-staging.yaml
+++ b/project-staging.yaml
@@ -2,12 +2,12 @@ specVersion: 0.2.0
 name: neumann-subql
 version: 0.0.4
 description: Any queries for subquery for OAK's neumann network
-repository: https://github.com/subquery/neumann-subql
+repository: https://github.com/oak/oak-subql
 schema:
   file: ./schema.graphql
 network:
-  endpoint: 'wss://rpc.turing.oak.tech'
-  genesisHash: '0x0f62b701fb12d02237a33b84818c11f621653d2b1614c777973babf4652b535d'
+  endpoint: 'wss://rpc.turing-staging.oak.tech'
+  genesisHash: '0xd54f0988402deb4548538626ce37e4a318441ea0529ca369400ebec4e04dfe4b'
   chaintypes:
     file: ./dist/chaintypes.js
 dataSources:

--- a/project.yaml
+++ b/project.yaml
@@ -1,8 +1,8 @@
 specVersion: 0.2.0
 name: neumann-subql
 version: 0.0.4
-description: Any queries for subquery for OAK's neumann network
-repository: https://github.com/subquery/neumann-subql
+description: Any queries for subquery for Turing network
+repository: https://github.com/oak/oak-subql
 schema:
   file: ./schema.graphql
 network:


### PR DESCRIPTION
Currently, in project.yaml, we connect to production node by default at neumann.api.onfinality.io/public-ws. But this endpoint appear to be down now. Upon switching to rightg endpoint, I can see data is started to index for existing mapping.

I'm switching it to our prod RPC node default, so that out of the box if someone run this they will connect to it.
I also add an extra project-staging.yaml. I will update the app structure to eventually we can run the indexer to connect to either prod/staging rpc env.

