### PR TITLE
escape $ char in shell code

### DIFF
--- a/docker/postgres/init/load-extensions.sh
+++ b/docker/postgres/init/load-extensions.sh
@@ -18,9 +18,9 @@ CREATE OR REPLACE FUNCTION generate_block_ulid(block_epoch integer) RETURNS uuid
 
 CREATE OR REPLACE FUNCTION to_uuid(raw text)
   RETURNS uuid IMMUTABLE STRICT
-  AS $$
+  AS \$\$
     BEGIN
       RETURN uuid_in(overlay(overlay(md5(raw) placing '4' from 13) placing '8' from 17)::cstring);
     END;
-$$ LANGUAGE plpgsql;
+\$\$ LANGUAGE plpgsql;
 EOF


### PR DESCRIPTION
This is just a helper function to generate UUID I used to allow us re-indexing(original subquery doesn' support re-index in-place, have to delete data and re-sync from scratch). 

I forgot to escape the $$.