### PR TITLE
configure, split superset for production/staging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,11 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 up: ## bring up everything in the right order
-	docker compose -f docker-compose-deps.yml -f docker-compose.yml -f docker-compose-app.yml up -d
+	docker compose -f docker-compose-deps.yml -f docker-compose-ss.yml -f docker-compose.yml -f docker-compose-app.yml build
+	docker compose -f docker-compose-deps.yml -f docker-compose-ss.yml -f docker-compose.yml -f docker-compose-app.yml up -d
 
 down: ## bring down everything in the right order
-	docker compose -f docker-compose-deps.yml -f docker-compose.yml -f docker-compose-app.yml down
+	docker compose -f docker-compose-deps.yml -f docker-compose-ss.yml -f docker-compose.yml -f docker-compose-app.yml down
 
 ###############################################################################
 #################################  Local Dev  #################################

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,3 +1,3 @@
-turing-staging.explorer.oak.tech {
+{$SITE_ADDRESS} {
   reverse_proxy graphql-engine:3000
 }

--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,3 +1,9 @@
 {$SITE_ADDRESS} {
   reverse_proxy graphql-engine:3000
 }
+
+{$INSIGHTS_ADDRESS} {
+  reverse_proxy superset:8088 {
+    header_up X-Forwarded-Proto https
+  }
+}

--- a/caddy/superset.Caddyfile
+++ b/caddy/superset.Caddyfile
@@ -1,4 +1,4 @@
-{$SITE_ADDRESS} {
+{$INSIGHTS_ADDRESS} {
   reverse_proxy superset:8088 {
     header_up X-Forwarded-Proto https
   }

--- a/caddy/superset.Caddyfile
+++ b/caddy/superset.Caddyfile
@@ -1,5 +1,0 @@
-{$INSIGHTS_ADDRESS} {
-  reverse_proxy superset:8088 {
-    header_up X-Forwarded-Proto https
-  }
-}

--- a/caddy/superset.Caddyfile
+++ b/caddy/superset.Caddyfile
@@ -1,0 +1,5 @@
+{$SITE_ADDRESS} {
+  reverse_proxy superset:8088 {
+    header_up X-Forwarded-Proto https
+  }
+}

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -24,6 +24,7 @@ services:
     image: caddy
     environment:
       SITE_ADDRESS: ${SITE_ADDRESS:-localhost}
+      INSIGHTS_ADDRESS: ${INSIGHTS_ADDRESS:-localhost}
     ports:
       - ${CADDY_PORT_HTTP:-8880}:80
       - ${CADDY_PORT_HTTPS:-8443}:443

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -22,6 +22,8 @@ services:
 
   caddy:
     image: caddy
+    environment:
+      SITE_ADDRESS: ${SITE_ADDRESS:-localhost}
     ports:
       - ${CADDY_PORT_HTTP:-8880}:80
       - ${CADDY_PORT_HTTPS:-8443}:443

--- a/docker-compose-ss.yml
+++ b/docker-compose-ss.yml
@@ -1,6 +1,5 @@
 x-superset-image: &superset-image apache/superset:${TAG:-latest-dev}
 x-superset-depends-on: &superset-depends-on
-  - db
   - redis
 x-superset-volumes: &superset-volumes
   # /app/pythonpath_docker will be appended to the PYTHONPATH in the final container
@@ -47,10 +46,22 @@ services:
     command: ["/app/docker/docker-bootstrap.sh", "app-gunicorn"]
     user: "root"
     restart: unless-stopped
-    ports:
-      - 8088:8088
     depends_on: *superset-depends-on
     volumes: *superset-volumes
+    networks:
+      - oak-subql
+
+  superset-caddy:
+    image: caddy
+    container_name: superset_caddy
+    environment:
+      SITE_ADDRESS: ${SITE_ADDRESS:-localhost}
+    ports:
+      - 8088:443
+    volumes:
+      - ./caddy/superset.Caddyfile:/etc/caddy/Caddyfile
+      - ${CADDY_DATA_PATH:-./data/caddy}:/data
+    restart: always
     networks:
       - oak-subql
 

--- a/docker-compose-ss.yml
+++ b/docker-compose-ss.yml
@@ -51,20 +51,6 @@ services:
     networks:
       - oak-subql
 
-  superset-caddy:
-    image: caddy
-    container_name: superset_caddy
-    environment:
-      SITE_ADDRESS: ${SITE_ADDRESS:-localhost}
-    ports:
-      - 8088:443
-    volumes:
-      - ./caddy/superset.Caddyfile:/etc/caddy/Caddyfile
-      - ${CADDY_DATA_PATH:-./data/caddy}:/data
-    restart: always
-    networks:
-      - oak-subql
-
   superset-init:
     image: *superset-image
     container_name: superset_init

--- a/docker/superset/pythonpath_dev/superset_config.py
+++ b/docker/superset/pythonpath_dev/superset_config.py
@@ -121,3 +121,5 @@ try:
     )
 except ImportError:
     logger.info("Using default Docker config...")
+
+ENABLE_PROXY_FIX = True

--- a/env.prod
+++ b/env.prod
@@ -1,0 +1,19 @@
+export STACK_ENV=prod
+export SITE_ADDRESS=turing.explorer.oak.tech
+
+export PG_DATA=/pg-data/
+
+export DB_USER=postgres
+export DB_PASS=${POSTGRES_PASSWORD}
+export DB_DATABASE=postgres
+export DB_HOST=postgres
+export DB_PORT=5432
+
+export CADDY_DATA_PATH=/data/caddy/
+export CADDY_PORT_HTTPS=443
+export CADDY_PORT_HTTP=80
+
+
+# Superset
+export SUPERSET_HOME_DATA=/data/superset_home
+export MAPBOX_API_KEY=''

--- a/env.prod
+++ b/env.prod
@@ -1,5 +1,6 @@
 export STACK_ENV=prod
 export SITE_ADDRESS=turing.explorer.oak.tech
+export INSIGHTS_ADDRESS=turing.insights.oak.tech
 
 export PG_DATA=/pg-data/
 

--- a/env.staging
+++ b/env.staging
@@ -1,0 +1,19 @@
+export STACK_ENV=staging
+export SITE_ADDRESS=turing-staging.explorer.oak.tech
+
+export PG_DATA=/pg-data/
+
+export DB_USER=postgres
+export DB_PASS=${POSTGRES_PASSWORD}
+export DB_DATABASE=postgres
+export DB_HOST=postgres
+export DB_PORT=5432
+
+export CADDY_DATA_PATH=/data/caddy/
+export CADDY_PORT_HTTPS=443
+export CADDY_PORT_HTTP=80
+
+
+# Superset
+export SUPERSET_HOME_DATA=/data/superset_home
+export MAPBOX_API_KEY=''

--- a/env.staging
+++ b/env.staging
@@ -1,5 +1,6 @@
 export STACK_ENV=staging
 export SITE_ADDRESS=turing-staging.explorer.oak.tech
+export INSIGHTS_ADDRESS=turing-staging.insights.oak.tech
 
 export PG_DATA=/pg-data/
 


### PR DESCRIPTION
We map superset directly to docker bind port so there was no HTTPS before. Also domain was hard code in the config file.

This PR turn the hard code URL into dynamic env so we can pass from docker compose. We now can use the same compose file or config to serve both production and staging, customize based on passed env var.

### Staging
graphql: https://turing-staging.explorer.oak.tech/
superset: https://turing-staging.explorer.oak.tech:8088 

### Production

graphql: https://turing.explorer.oak.tech/
superset: https://turing.explorer.oak.tech:8088