### PR TITLE
add dedicate API domain mapping

### DIFF
--- a/caddy/Caddyfile
+++ b/caddy/Caddyfile
@@ -1,5 +1,19 @@
+(cors) {
+  header_down Access-Control-Allow-Origin  *
+  header_down Access-Control-Allow-Methods "OPTIONS, DELETE, GET, HEAD, POST, PUT"
+}
+
+
 {$SITE_ADDRESS} {
-  reverse_proxy graphql-engine:3000
+  reverse_proxy graphql-engine:3000 {
+	  import cors *
+  }
+}
+
+{$API_ADDRESS} {
+  reverse_proxy graphql-engine:3000 {
+	  import cors *
+  }
 }
 
 {$INSIGHTS_ADDRESS} {

--- a/docker-compose-app.yml
+++ b/docker-compose-app.yml
@@ -24,6 +24,7 @@ services:
     image: caddy
     environment:
       SITE_ADDRESS: ${SITE_ADDRESS:-localhost}
+      API_ADDRESS: ${API_ADDRESS:-localhost}
       INSIGHTS_ADDRESS: ${INSIGHTS_ADDRESS:-localhost}
     ports:
       - ${CADDY_PORT_HTTP:-8880}:80

--- a/env.prod
+++ b/env.prod
@@ -1,8 +1,9 @@
 export STACK_ENV=prod
 export SITE_ADDRESS=turing.explorer.oak.tech
+export API_ADDRESS=graphql.turing.api.oak.tech
 export INSIGHTS_ADDRESS=turing.insights.oak.tech
 
-export PG_DATA=/pg-data/
+export PG_DATA=/data/pg-data/
 
 export DB_USER=postgres
 export DB_PASS=${POSTGRES_PASSWORD}

--- a/env.staging
+++ b/env.staging
@@ -1,5 +1,6 @@
 export STACK_ENV=staging
 export SITE_ADDRESS=turing-staging.explorer.oak.tech
+export API_ADDRESS=graphql.turing-staging.api.oak.tech
 export INSIGHTS_ADDRESS=turing-staging.insights.oak.tech
 
 export PG_DATA=/pg-data/


### PR DESCRIPTION
We were sharing the same domain and use Accept header to route to GraphiQL or the GraphQL server.

Now we splited them to use a deciated API domain for API